### PR TITLE
fix(release): npm publish glob expansion + prerelease dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
     environment: release          # requires manual approval in repo Settings → Environments
     permissions:
       contents: write
+      id-token: write             # required for OIDC trusted publishing to npm
 
     steps:
       - uses: actions/checkout@v6
@@ -139,6 +140,11 @@ jobs:
           path: dist-release
 
       - name: Publish to npm
-        run: npm publish dist-release/*.tgz
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+        run: |
+          TARBALL=$(ls dist-release/*.tgz)
+          if [ "${{ needs.draft.outputs.prerelease }}" = "true" ]; then
+            DIST_TAG=$(echo "${{ needs.draft.outputs.version }}" | grep -oE '(alpha|beta|rc|pre)' | head -1)
+            npm publish "$TARBALL" --provenance --tag "${DIST_TAG:-prerelease}"
+          else
+            npm publish "$TARBALL" --provenance
+          fi


### PR DESCRIPTION
## Summary

- `npm publish dist-release/*.tgz` — npm не розкриває glob, передавав `dist-release/*.tgz` буквально як git URL → exit 128. Виправлено через `$(ls dist-release/*.tgz)`.
- Без `--tag` npm присвоює `latest` будь-якому релізу — `v3.0.0-beta.0` ставав би дефолтним для `npm install js-ballistics`. Тепер для пре-релізів витягується ідентифікатор (`beta`/`alpha`/`rc`) і передається як `--tag`; стабільні релізи публікуються без тегу.

## Test plan

- [ ] Перезапустити `release` workflow для `v3.0.0-beta.0` і перевірити що `npm publish` проходить
- [ ] Перевірити що пакет опублікований з тегом `beta` (`npm dist-tag ls js-ballistics`)
- [ ] Перевірити що `npm install js-ballistics` не тягне бету (`latest` → попередня стабільна)